### PR TITLE
Make it run in x86_64, fix build and compilation issues

### DIFF
--- a/linuxdoom-1.10/Makefile
+++ b/linuxdoom-1.10/Makefile
@@ -6,7 +6,7 @@
 #
 CC=  gcc  # gcc or g++
 
-CFLAGS=-g -Wall -DNORMALUNIX -DLINUX # -DUSEASM 
+CFLAGS=-g -Wall -DNORMALUNIX -DLINUX -DSNDSERV -DSNDSRV # -DUSEASM 
 LDFLAGS=-L/usr/X11R6/lib
 LIBS=-lXext -lX11 -lnsl -lm
 

--- a/linuxdoom-1.10/Makefile
+++ b/linuxdoom-1.10/Makefile
@@ -81,14 +81,17 @@ all:	 $(O)/linuxxdoom
 
 clean:
 	rm -f *.o *~ *.flc
-	rm -f linux/*
+	rm -rf linux
 
 $(O)/linuxxdoom:	$(OBJS) $(O)/i_main.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) $(O)/i_main.o \
 	-o $(O)/linuxxdoom $(LIBS)
 
-$(O)/%.o:	%.c
+$(O)/%.o:	%.c | object
 	$(CC) $(CFLAGS) -c $< -o $@
+
+object:
+	mkdir -p $(O)
 
 #############################################################
 #

--- a/linuxdoom-1.10/i_sound.c
+++ b/linuxdoom-1.10/i_sound.c
@@ -27,7 +27,7 @@ rcsid[] = "$Id: i_unix.c,v 1.5 1997/02/03 22:45:10 b1 Exp $";
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
-
+#include <errno.h>
 #include <math.h>
 
 #include <sys/time.h>
@@ -163,7 +163,6 @@ myioctl
   int*	arg )
 {   
     int		rc;
-    extern int	errno;
     
     rc = ioctl(fd, command, arg);  
     if (rc < 0)

--- a/linuxdoom-1.10/i_video.c
+++ b/linuxdoom-1.10/i_video.c
@@ -46,7 +46,7 @@ int XShmGetEventBase( Display* dpy ); // problems with g++?
 #include <sys/socket.h>
 
 #include <netinet/in.h>
-#include <errnos.h>
+#include <errno.h>
 #include <signal.h>
 
 #include "doomstat.h"

--- a/linuxdoom-1.10/m_misc.c
+++ b/linuxdoom-1.10/m_misc.c
@@ -226,7 +226,7 @@ typedef struct
 {
     char*	name;
     int*	location;
-    int		defaultvalue;
+    long long	defaultvalue;
     int		scantranslate;		// PC scan code hack
     int		untranslated;		// lousy hack
 } default_t;
@@ -254,15 +254,15 @@ default_t	defaults[] =
 
 // UNIX hack, to be removed. 
 #ifdef SNDSERV
-    {"sndserver", (int *) &sndserver_filename, (int) "sndserver"},
+    {"sndserver", (int *) &sndserver_filename, (long long int) "sndserver"},
     {"mb_used", &mb_used, 2},
 #endif
     
 #endif
 
 #ifdef LINUX
-    {"mousedev", (int*)&mousedev, (int)"/dev/ttyS0"},
-    {"mousetype", (int*)&mousetype, (int)"microsoft"},
+    {"mousedev", (int*)&mousedev, (long long int)"/dev/ttyS0"},
+    {"mousetype", (int*)&mousetype, (long long int)"microsoft"},
 #endif
 
     {"use_mouse",&usemouse, 1},
@@ -285,16 +285,16 @@ default_t	defaults[] =
 
     {"usegamma",&usegamma, 0},
 
-    {"chatmacro0", (int *) &chat_macros[0], (int) HUSTR_CHATMACRO0 },
-    {"chatmacro1", (int *) &chat_macros[1], (int) HUSTR_CHATMACRO1 },
-    {"chatmacro2", (int *) &chat_macros[2], (int) HUSTR_CHATMACRO2 },
-    {"chatmacro3", (int *) &chat_macros[3], (int) HUSTR_CHATMACRO3 },
-    {"chatmacro4", (int *) &chat_macros[4], (int) HUSTR_CHATMACRO4 },
-    {"chatmacro5", (int *) &chat_macros[5], (int) HUSTR_CHATMACRO5 },
-    {"chatmacro6", (int *) &chat_macros[6], (int) HUSTR_CHATMACRO6 },
-    {"chatmacro7", (int *) &chat_macros[7], (int) HUSTR_CHATMACRO7 },
-    {"chatmacro8", (int *) &chat_macros[8], (int) HUSTR_CHATMACRO8 },
-    {"chatmacro9", (int *) &chat_macros[9], (int) HUSTR_CHATMACRO9 }
+    {"chatmacro0", (int *) &chat_macros[0], (long long int) HUSTR_CHATMACRO0 },
+    {"chatmacro1", (int *) &chat_macros[1], (long long int) HUSTR_CHATMACRO1 },
+    {"chatmacro2", (int *) &chat_macros[2], (long long int) HUSTR_CHATMACRO2 },
+    {"chatmacro3", (int *) &chat_macros[3], (long long int) HUSTR_CHATMACRO3 },
+    {"chatmacro4", (int *) &chat_macros[4], (long long int) HUSTR_CHATMACRO4 },
+    {"chatmacro5", (int *) &chat_macros[5], (long long int) HUSTR_CHATMACRO5 },
+    {"chatmacro6", (int *) &chat_macros[6], (long long int) HUSTR_CHATMACRO6 },
+    {"chatmacro7", (int *) &chat_macros[7], (long long int) HUSTR_CHATMACRO7 },
+    {"chatmacro8", (int *) &chat_macros[8], (long long int) HUSTR_CHATMACRO8 },
+    {"chatmacro9", (int *) &chat_macros[9], (long long int) HUSTR_CHATMACRO9 }
 
 };
 

--- a/linuxdoom-1.10/p_setup.c
+++ b/linuxdoom-1.10/p_setup.c
@@ -533,7 +533,7 @@ void P_GroupLines (void)
     }
 	
     // build line tables for each sector	
-    linebuffer = Z_Malloc (total*4, PU_LEVEL, 0);
+    linebuffer = Z_Malloc (total*sizeof(*linebuffer), PU_LEVEL, 0);
     sector = sectors;
     for (i=0 ; i<numsectors ; i++, sector++)
     {

--- a/linuxdoom-1.10/r_data.c
+++ b/linuxdoom-1.10/r_data.c
@@ -27,6 +27,8 @@
 static const char
 rcsid[] = "$Id: r_data.c,v 1.4 1997/02/03 16:47:55 b1 Exp $";
 
+#include <stdint.h>
+
 #include "i_system.h"
 #include "z_zone.h"
 
@@ -87,7 +89,7 @@ typedef struct
     boolean		masked;	
     short		width;
     short		height;
-    void		**columndirectory;	// OBSOLETE
+    int			columndirectory;	// OBSOLETE
     short		patchcount;
     mappatch_t	patches[1];
 } maptexture_t;
@@ -479,10 +481,10 @@ void R_InitTextures (void)
     }
     numtextures = numtextures1 + numtextures2;
 	
-    textures = Z_Malloc (numtextures*4, PU_STATIC, 0);
-    texturecolumnlump = Z_Malloc (numtextures*4, PU_STATIC, 0);
-    texturecolumnofs = Z_Malloc (numtextures*4, PU_STATIC, 0);
-    texturecomposite = Z_Malloc (numtextures*4, PU_STATIC, 0);
+    textures = Z_Malloc (numtextures*sizeof(*textures), PU_STATIC, 0);
+    texturecolumnlump = Z_Malloc (numtextures*sizeof(*texturecolumnlump), PU_STATIC, 0);
+    texturecolumnofs = Z_Malloc (numtextures*sizeof(*texturecolumnofs), PU_STATIC, 0);
+    texturecomposite = Z_Malloc (numtextures*sizeof(*texturecomposite), PU_STATIC, 0);
     texturecompositesize = Z_Malloc (numtextures*4, PU_STATIC, 0);
     texturewidthmask = Z_Malloc (numtextures*4, PU_STATIC, 0);
     textureheight = Z_Malloc (numtextures*4, PU_STATIC, 0);
@@ -639,7 +641,7 @@ void R_InitColormaps (void)
     lump = W_GetNumForName("COLORMAP"); 
     length = W_LumpLength (lump) + 255; 
     colormaps = Z_Malloc (length, PU_STATIC, 0); 
-    colormaps = (byte *)( ((int)colormaps + 255)&~0xff); 
+    colormaps = (byte *)( ((intptr_t)colormaps + 255)&~0xff); 
     W_ReadLump (lump,colormaps); 
 }
 

--- a/linuxdoom-1.10/r_draw.c
+++ b/linuxdoom-1.10/r_draw.c
@@ -27,6 +27,7 @@
 static const char
 rcsid[] = "$Id: r_draw.c,v 1.4 1997/02/03 16:47:55 b1 Exp $";
 
+#include <stdint.h>
 
 #include "doomdef.h"
 
@@ -461,7 +462,7 @@ void R_InitTranslationTables (void)
     int		i;
 	
     translationtables = Z_Malloc (256*3+255, PU_STATIC, 0);
-    translationtables = (byte *)(( (int)translationtables + 255 )& ~255);
+    translationtables = (byte *)(( (intptr_t)translationtables + 255 )& ~255);
     
     // translate just the 16 green colors
     for (i=0 ; i<256 ; i++)


### PR DESCRIPTION
The 8 bit palette is necessary. so run this in a terminal, press ctrl + alt + f2, open terminal there and execute linuxxdoom from there.
`$ sudo startx -- :1 -depth 8 vt2`