### PR TITLE
fix: doomu.wad is 9 chars not 8 chars long

### DIFF
--- a/linuxdoom-1.10/d_main.c
+++ b/linuxdoom-1.10/d_main.c
@@ -584,7 +584,7 @@ void IdentifyVersion (void)
     sprintf(doom2wad, "%s/doom2.wad", doomwaddir);
 
     // Retail.
-    doomuwad = malloc(strlen(doomwaddir)+1+8+1);
+    doomuwad = malloc(strlen(doomwaddir)+1+9+1);
     sprintf(doomuwad, "%s/doomu.wad", doomwaddir);
     
     // Registered.


### PR DESCRIPTION
I just noticed this issue when browsing the source of d_main.c.  The calculation of `strlen(doomwaddir) + strlen("/") + strlen("doomu.wad") + strlen("\0")` seems to be off by one.  sprintf will (theoretically) overrun the buffer.