### PR TITLE
fixed a minor endianness bug

### DIFF
--- a/linuxdoom-1.10/m_swap.c
+++ b/linuxdoom-1.10/m_swap.c
@@ -31,8 +31,9 @@ rcsid[] = "$Id: m_bbox.c,v 1.1 1997/02/03 22:45:10 b1 Exp $";
 #include "m_swap.h"
 
 
-// Not needed with big endian.
-#ifndef __BIG_ENDIAN__
+// Needed for Big Endian as the WAD files are stored
+// in Little Endian format (as mentioned in the m_swap.h file)
+#ifdef __BIG_ENDIAN__
 
 // Swap 16bit, that is, MSB and LSB byte.
 unsigned short SwapSHORT(unsigned short x)


### PR DESCRIPTION
The m_swap.h file mentions that the WAD files contain the data in Little Endian format. So, in case of Big Endian machines, we should define and use the SwapSHORT and SwapLONG functions.